### PR TITLE
👾 fix: Update hero docs link button path

### DIFF
--- a/docs/src/components/landing/hero.tsx
+++ b/docs/src/components/landing/hero.tsx
@@ -77,7 +77,7 @@ export default function Hero() {
               </div>
               <div className="mt-8 flex w-fit flex-col gap-4 font-sans md:flex-row md:justify-center lg:justify-start items-center">
                 <Link
-                  href="/docs"
+                  href="/docs/introduction"
                   className="hover:shadow-sm dark:border-stone-100 dark:hover:shadow-sm border-2 border-black bg-white px-4 py-1.5 text-sm uppercase text-black shadow-[1px_1px_rgba(0,0,0),2px_2px_rgba(0,0,0),3px_3px_rgba(0,0,0),4px_4px_rgba(0,0,0),5px_5px_0px_0px_rgba(0,0,0)] transition duration-200 md:px-8 dark:shadow-[1px_1px_rgba(255,255,255),2px_2px_rgba(255,255,255),3px_3px_rgba(255,255,255),4px_4px_rgba(255,255,255),5px_5px_0px_0px_rgba(255,255,255)]"
                 >
                   Get Started


### PR DESCRIPTION
Currently clicking on `Get started` redirects to 

![image](https://github.com/user-attachments/assets/a6e38e3f-84b7-4855-b0be-e5f4e35f5563)


![image](https://github.com/user-attachments/assets/9ef11239-b001-4527-911f-515a88a230d2)
