### PR TITLE
fix: better auth client url

### DIFF
--- a/packages/payload-auth/src/better-auth/plugin/lib/apply-disabled-default-auth-config.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/apply-disabled-default-auth-config.ts
@@ -26,6 +26,7 @@ export function applyDisabledDefaultAuthConfig({
         {
           path: 'payload-auth/better-auth/plugin/rsc#RSCRedirect',
           serverProps: {
+            pluginOptions,
             redirectTo: `${config.routes?.admin === undefined ? '/admin' : config.routes.admin.replace(/\/+$/, '')}${adminRoutes.adminLogin}`
           }
         },
@@ -43,7 +44,7 @@ export function applyDisabledDefaultAuthConfig({
           Component: {
             path: 'payload-auth/better-auth/plugin/rsc#AdminLogin',
             serverProps: {
-              pluginOptions: pluginOptions,
+              pluginOptions,
               adminInvitationsSlug: collectionMap[baseSlugs.adminInvitations].slug
             }
           }
@@ -53,7 +54,7 @@ export function applyDisabledDefaultAuthConfig({
           Component: {
             path: 'payload-auth/better-auth/plugin/rsc#AdminSignup',
             serverProps: {
-              pluginOptions: pluginOptions,
+              pluginOptions,
               adminInvitationsSlug: collectionMap[baseSlugs.adminInvitations].slug
             }
           }
@@ -61,13 +62,19 @@ export function applyDisabledDefaultAuthConfig({
         forgotPassword: {
           path: adminRoutes.forgotPassword,
           Component: {
-            path: 'payload-auth/better-auth/plugin/rsc#ForgotPassword'
+            path: 'payload-auth/better-auth/plugin/rsc#ForgotPassword',
+            serverProps: {
+              pluginOptions
+            }
           }
         },
         resetPassword: {
           path: adminRoutes.resetPassword,
           Component: {
-            path: 'payload-auth/better-auth/plugin/rsc#ResetPassword'
+            path: 'payload-auth/better-auth/plugin/rsc#ResetPassword',
+            serverProps: {
+              pluginOptions
+            }
           }
         },
         ...(checkPluginExists(pluginOptions.betterAuthOptions ?? {}, supportedBAPluginIds.twoFactor) && {

--- a/packages/payload-auth/src/better-auth/plugin/lib/apply-disabled-default-auth-config.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/apply-disabled-default-auth-config.ts
@@ -26,7 +26,7 @@ export function applyDisabledDefaultAuthConfig({
         {
           path: 'payload-auth/better-auth/plugin/rsc#RSCRedirect',
           serverProps: {
-            redirectTo: `${config.routes?.admin === undefined ? '/admin' : config.routes.admin}${adminRoutes.adminLogin}`
+            redirectTo: `${config.routes?.admin === undefined ? '/admin' : config.routes.admin.replace(/\/+$/, '')}${adminRoutes.adminLogin}`
           }
         },
         ...(config.admin?.components?.afterLogin || [])
@@ -89,4 +89,4 @@ export function applyDisabledDefaultAuthConfig({
       login: adminRoutes.loginRedirect
     }
   }
-} 
+}

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/users/index.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/users/index.ts
@@ -45,7 +45,7 @@ export function buildUsersCollection({ incomingCollections, pluginOptions, resol
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => field.fieldName === 'createdAt' ? t('general:createdAt') : t('general:updatedAt')
+        label: ({ t }: any) => (field.fieldName === 'createdAt' ? t('general:createdAt') : t('general:updatedAt'))
       })
     }
   ]
@@ -156,7 +156,9 @@ export function buildUsersCollection({ incomingCollections, pluginOptions, resol
                 Component: {
                   path: 'payload-auth/better-auth/plugin/client#AdminButtons',
                   clientProps: {
-                    userSlug
+                    userSlug,
+                    baseURL: pluginOptions.betterAuthOptions?.baseURL,
+                    basePath: pluginOptions.betterAuthOptions?.basePath
                   }
                 },
                 condition: () => {
@@ -242,7 +244,8 @@ export function buildUsersCollection({ incomingCollections, pluginOptions, resol
                     path: 'payload-auth/better-auth/plugin/rsc#Passkeys',
                     serverProps: {
                       passkeyUserIdFieldName,
-                      passkeySlug
+                      passkeySlug,
+                      pluginOptions
                     }
                   }
                 }

--- a/packages/payload-auth/src/better-auth/plugin/payload/components/admin-buttons/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/components/admin-buttons/index.tsx
@@ -10,9 +10,11 @@ import './index.scss'
 
 type AdminButtonsProps = {
   userSlug: string
+  baseURL?: string
+  basePath?: string
 }
 
-export const AdminButtons: React.FC<AdminButtonsProps> = () => {
+export const AdminButtons: React.FC<AdminButtonsProps> = ({ baseURL, basePath }) => {
   const router = useRouter()
   const { id } = useDocumentInfo()
   const isBanned = useFormFields(([fields]) => fields.banned)
@@ -24,6 +26,8 @@ export const AdminButtons: React.FC<AdminButtonsProps> = () => {
   const authClient = useMemo(
     () =>
       createAuthClient({
+        baseURL,
+        basePath,
         plugins: [adminClient()]
       }),
     []

--- a/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/add-button.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/add-button.tsx
@@ -13,11 +13,13 @@ const baseClass = 'passkeys-modal'
 
 interface PassKeyAddButtonProps {
   onAdd?: () => void
+  baseURL?: string
+  basePath?: string
 }
 
-export const PassKeyAddButton: React.FC<PassKeyAddButtonProps> = ({ onAdd }) => {
+export const PassKeyAddButton: React.FC<PassKeyAddButtonProps> = ({ onAdd, baseURL, basePath }) => {
   const { openModal, closeModal } = useModal()
-  const authClient = useMemo(() => createAuthClient({ plugins: [passkeyClient()] }), [])
+  const authClient = useMemo(() => createAuthClient({ baseURL, basePath, plugins: [passkeyClient()] }), [])
 
   const AddPasskeyForm: React.FC = () => {
     const [isLoading, setIsLoading] = useState(false)
@@ -39,7 +41,7 @@ export const PassKeyAddButton: React.FC<PassKeyAddButtonProps> = ({ onAdd }) => 
         closeModal('passkeys-modal')
         if (typeof onAdd === 'function') onAdd()
       },
-      validators: { 
+      validators: {
         onSubmit: nameSchema
       }
     })

--- a/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/client.tsx
@@ -11,7 +11,9 @@ export const PasskeysClient: React.FC<PasskeysClientComponentProps> = ({
   documentId,
   currentUserId,
   passkeySlug,
-  passkeyUserIdFieldName
+  passkeyUserIdFieldName,
+  baseURL,
+  basePath
 }) => {
   const {
     config: {
@@ -33,11 +35,14 @@ export const PasskeysClient: React.FC<PasskeysClientComponentProps> = ({
     void fetchPasskeys()
   }, [fetchPasskeys])
 
-  const handleDelete = useCallback(async (id: string) => {
-    const res = await fetch(`${apiRoute}/${passkeySlug}/${id}`, { method: 'DELETE', credentials: 'include' })
-    if (!res.ok) return
-    void fetchPasskeys()
-  }, [apiRoute, passkeySlug, fetchPasskeys])
+  const handleDelete = useCallback(
+    async (id: string) => {
+      const res = await fetch(`${apiRoute}/${passkeySlug}/${id}`, { method: 'DELETE', credentials: 'include' })
+      if (!res.ok) return
+      void fetchPasskeys()
+    },
+    [apiRoute, passkeySlug, fetchPasskeys]
+  )
 
   const handleAdd = useCallback(() => {
     void fetchPasskeys()
@@ -46,7 +51,7 @@ export const PasskeysClient: React.FC<PasskeysClientComponentProps> = ({
   return (
     <>
       <PasskeyList passkeys={passkeys} onDelete={handleDelete} />
-      {currentUserId === documentId && <PassKeyAddButton onAdd={handleAdd} />}
+      {currentUserId === documentId && <PassKeyAddButton onAdd={handleAdd} baseURL={baseURL} basePath={basePath} />}
     </>
   )
 }

--- a/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/index.tsx
@@ -4,11 +4,11 @@ import './index.scss'
 import type { PasskeysServerComponentProps, PasskeyWithId } from './types'
 
 export const Passkeys: React.FC<PasskeysServerComponentProps> = async (props) => {
-  const { id, passkeySlug, payload, passkeyUserIdFieldName, req, user } = props
+  const { id, passkeySlug, payload, passkeyUserIdFieldName, req, user, pluginOptions } = props
 
   if (!id || !passkeySlug || !passkeyUserIdFieldName) return null
 
-  const { docs: userPasskeys } = await payload.find({
+  const { docs: userPasskeys } = (await payload.find({
     collection: passkeySlug,
     where: {
       [passkeyUserIdFieldName]: { equals: id }
@@ -16,7 +16,7 @@ export const Passkeys: React.FC<PasskeysServerComponentProps> = async (props) =>
     limit: 100,
     req,
     depth: 0
-  }) as unknown as { docs: PasskeyWithId[] }
+  })) as unknown as { docs: PasskeyWithId[] }
 
   return (
     <div className="passkeys-field">
@@ -29,6 +29,8 @@ export const Passkeys: React.FC<PasskeysServerComponentProps> = async (props) =>
         currentUserId={user?.id}
         passkeySlug={passkeySlug}
         passkeyUserIdFieldName={passkeyUserIdFieldName}
+        baseURL={pluginOptions.betterAuthOptions?.baseURL}
+        basePath={pluginOptions.betterAuthOptions?.basePath}
       />
     </div>
   )

--- a/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/types.ts
+++ b/packages/payload-auth/src/better-auth/plugin/payload/components/passkeys/types.ts
@@ -1,5 +1,5 @@
 import type { UIFieldServerProps } from 'payload'
-import type { BuiltBetterAuthSchema } from '@/better-auth/types'
+import type { BetterAuthPluginOptions, BuiltBetterAuthSchema } from '@/better-auth/types'
 import type { Passkey } from '@/better-auth/generated-types'
 
 export type PasskeyWithId = Passkey & { id: string; createdAt: Date }
@@ -8,6 +8,7 @@ export type PasskeysServerComponentProps = UIFieldServerProps & {
   schema: BuiltBetterAuthSchema
   passkeySlug: string
   passkeyUserIdFieldName: string
+  pluginOptions: BetterAuthPluginOptions
 }
 
 export type PasskeysClientComponentProps = {
@@ -16,5 +17,6 @@ export type PasskeysClientComponentProps = {
   currentUserId: string | number
   passkeySlug: string
   passkeyUserIdFieldName: string
+  baseURL?: string
+  basePath?: string
 }
-

--- a/packages/payload-auth/src/better-auth/plugin/payload/components/social-provider-buttons/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/components/social-provider-buttons/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { socialProviders } from '@/better-auth/plugin/constants'
-import type { LoginMethod, SocialProvider } from '@/better-auth/plugin/types'
+import type { BetterAuthPluginOptions, LoginMethod, SocialProvider } from '@/better-auth/plugin/types'
 import { Icons } from '@/shared/components/icons'
 import { Button, toast } from '@payloadcms/ui'
 import { passkeyClient } from 'better-auth/client/plugins'
@@ -18,6 +18,8 @@ type AdminSocialProviderButtonsProps = {
   redirectUrl?: string
   newUserCallbackURL?: string
   adminInviteToken?: string
+  baseURL?: string
+  basePath?: string
 }
 
 const baseClass = 'admin-social-provider-buttons'
@@ -28,12 +30,22 @@ export const AdminSocialProviderButtons: React.FC<AdminSocialProviderButtonsProp
   setLoading,
   redirectUrl,
   newUserCallbackURL,
-  adminInviteToken
+  adminInviteToken,
+  baseURL,
+  basePath
 }) => {
   const router = useRouter()
-  const authClient = useMemo(() => createAuthClient({ plugins: [passkeyClient()] }), [])
-  
-  const loginMethodCount = loginMethods.filter(method => method !== 'emailPassword', 'passkey').length
+  const authClient = useMemo(
+    () =>
+      createAuthClient({
+        baseURL,
+        basePath,
+        plugins: [passkeyClient()]
+      }),
+    []
+  )
+
+  const loginMethodCount = loginMethods.filter((method) => method !== 'emailPassword', 'passkey').length
   if (loginMethodCount === 0) return null
 
   const showIconOnly = loginMethodCount >= 3
@@ -48,8 +60,8 @@ export const AdminSocialProviderButtons: React.FC<AdminSocialProviderButtonsProp
             textTransform: 'uppercase',
             marginTop: '-.5rem',
             color: 'var(--theme-elevation-450)',
-          marginBottom: '1.5rem'
-        }}>
+            marginBottom: '1.5rem'
+          }}>
           <span>Or {isSignup ? 'sign up' : 'login'} with</span>
         </div>
       )}
@@ -113,7 +125,7 @@ export const AdminSocialProviderButtons: React.FC<AdminSocialProviderButtonsProp
                   errorCallbackURL: window.location.href,
                   callbackURL: redirectUrl,
                   newUserCallbackURL,
-                  ...(isSignup && { requestSignUp: true }),
+                  ...(isSignup && { requestSignUp: true })
                 })
 
                 if (error) {
@@ -133,7 +145,7 @@ export const AdminSocialProviderButtons: React.FC<AdminSocialProviderButtonsProp
                 size="large"
                 className={`${baseClass}__button provider--${loginMethod}`}
                 onClick={handleSocialClick}
-                iconPosition='left'
+                iconPosition="left"
                 icon={<Icon className={`${baseClass}__icon`} />}
                 tooltip={showIconOnly ? `Sign in with ${providerName}` : undefined}>
                 {!showIconOnly && <span>{providerName}</span>}

--- a/packages/payload-auth/src/better-auth/plugin/payload/components/two-factor-auth/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/components/two-factor-auth/index.tsx
@@ -15,7 +15,12 @@ import { useAppForm } from '@/shared/form'
 
 const baseClass = 'two-factor-auth-modal'
 
-export const TwoFactorAuth: React.FC = () => {
+type TwoFactorAuthProps = {
+  baseURL?: string
+  basePath?: string
+}
+
+export const TwoFactorAuth: React.FC<TwoFactorAuthProps> = ({ baseURL, basePath }) => {
   const [totpURI, setTotpURI] = useState('')
   const [backupCodes, setBackupCodes] = useState<string[] | null>(null)
   const [formState, setFormState] = useState<'enable' | 'verify' | 'backupCodes' | 'disable'>('enable')
@@ -25,7 +30,7 @@ export const TwoFactorAuth: React.FC = () => {
   const twoFactorEnabled = Boolean(twoFactorEnabledField?.value)
   const { setValue: setTwoFactorEnabled } = useField({ path: 'twoFactorEnabled' })
 
-  const authClient = useMemo(() => createAuthClient({ plugins: [twoFactorClient()] }), [])
+  const authClient = useMemo(() => createAuthClient({ baseURL, basePath, plugins: [twoFactorClient()] }), [])
 
   const copyURI = async () => {
     if (!totpURI) return

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/client.tsx
@@ -86,11 +86,6 @@ const LoginForm: React.FC<{
     if (canLoginWithUsername && hasUsernamePlugin) return 'username'
     return 'email'
   }, [canLoginWithEmail, canLoginWithUsername, hasUsernamePlugin])
-  const [requireEmailVerification, setRequireEmailVerification] = useState<boolean>(false)
-
-  if (requireEmailVerification) {
-    return <FormHeader heading="Please verify your email" description={t('authentication:emailSent')} style={{ textAlign: 'center' }} />
-  }
 
   const loginSchema = createLoginSchema({ t, loginType, canLoginWithUsername })
 
@@ -126,6 +121,12 @@ const LoginForm: React.FC<{
       onSubmit: loginSchema
     }
   })
+
+  const [requireEmailVerification, setRequireEmailVerification] = useState<boolean>(false)
+
+  if (requireEmailVerification) {
+    return <FormHeader heading="Please verify your email" description={t('authentication:emailSent')} style={{ textAlign: 'center' }} />
+  }
 
   const getLoginTypeLabel = () => {
     const labels = {

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/client.tsx
@@ -26,6 +26,8 @@ type AdminLoginClientProps = {
   prefillUsername?: string
   searchParams: { [key: string]: string | string[] | undefined }
   loginWithUsername: false | LoginWithUsernameOptions
+  baseURL?: string
+  basePath?: string
 }
 
 const baseClass = 'login__form'
@@ -38,7 +40,19 @@ const LoginForm: React.FC<{
   prefillUsername?: string
   searchParams: { [key: string]: string | string[] | undefined }
   loginWithUsername: false | LoginWithUsernameOptions
-}> = ({ hasUsernamePlugin, hasPasskeyPlugin, prefillEmail, prefillPassword, prefillUsername, searchParams, loginWithUsername }) => {
+  baseURL?: string
+  basePath?: string
+}> = ({
+  hasUsernamePlugin,
+  hasPasskeyPlugin,
+  prefillEmail,
+  prefillPassword,
+  prefillUsername,
+  searchParams,
+  loginWithUsername,
+  baseURL,
+  basePath
+}) => {
   const { config } = useConfig()
   const router = useRouter()
   const adminRoute = valueOrDefaultString(config?.routes?.admin, '/admin')
@@ -53,6 +67,8 @@ const LoginForm: React.FC<{
   const authClient = useMemo(
     () =>
       createAuthClient({
+        baseURL,
+        basePath,
         plugins: [
           usernameClient(),
           twoFactorClient({
@@ -132,12 +148,24 @@ const LoginForm: React.FC<{
         <FormInputWrap className={baseClass}>
           <form.AppField
             name="login"
-            children={(field) => <field.TextField type="text" className="email" autoComplete={`email${hasPasskeyPlugin ? ' webauthn' : ''}`} label={getLoginTypeLabel()} />}
+            children={(field) => (
+              <field.TextField
+                type="text"
+                className="email"
+                autoComplete={`email${hasPasskeyPlugin ? ' webauthn' : ''}`}
+                label={getLoginTypeLabel()}
+              />
+            )}
           />
           <form.AppField
             name="password"
             children={(field) => (
-              <field.TextField type="password" className="password" autoComplete={`password${hasPasskeyPlugin ? ' webauthn' : ''}`} label={t('general:password')} />
+              <field.TextField
+                type="password"
+                className="password"
+                autoComplete={`password${hasPasskeyPlugin ? ' webauthn' : ''}`}
+                label={t('general:password')}
+              />
             )}
           />
         </FormInputWrap>
@@ -159,7 +187,9 @@ export const AdminLoginClient: React.FC<AdminLoginClientProps> = ({
   prefillPassword,
   prefillUsername,
   searchParams,
-  loginWithUsername
+  loginWithUsername,
+  baseURL,
+  basePath
 }) => {
   return (
     <>
@@ -172,6 +202,8 @@ export const AdminLoginClient: React.FC<AdminLoginClientProps> = ({
           prefillUsername={prefillUsername}
           searchParams={searchParams}
           loginWithUsername={loginWithUsername}
+          baseURL={baseURL}
+          basePath={basePath}
         />
       )}
       <AdminSocialProviderButtons
@@ -179,6 +211,8 @@ export const AdminLoginClient: React.FC<AdminLoginClientProps> = ({
         loginMethods={loginMethods}
         setLoading={() => {}}
         redirectUrl={getSafeRedirect(searchParams?.redirect as string, useConfig().config.routes.admin)}
+        baseURL={baseURL}
+        basePath={basePath}
       />
     </>
   )

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/index.tsx
@@ -133,6 +133,8 @@ const AdminLogin: React.FC<AdminLoginProps> = async ({
         prefillPassword={prefillPassword}
         prefillUsername={prefillUsername}
         searchParams={searchParams ?? {}}
+        baseURL={pluginOptions.betterAuthOptions?.baseURL}
+        basePath={pluginOptions.betterAuthOptions?.basePath}
       />
       {RenderServerComponent({
         Component: filteredAfterLogin,

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/admin-signup/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/admin-signup/client.tsx
@@ -11,7 +11,6 @@ import { useAppForm } from '@/shared/form'
 import { Form, FormInputWrap } from '@/shared/form/ui'
 import { FormHeader } from '@/shared/form/ui/header'
 import { createSignupSchema } from '@/shared/form/validation'
-import { tryCatch } from '@/shared/utils/try-catch'
 import { createAuthClient } from 'better-auth/react'
 import { usernameClient } from 'better-auth/client/plugins'
 
@@ -21,6 +20,8 @@ type AdminSignupClientProps = {
   loginMethods: LoginMethod[]
   searchParams: { [key: string]: string | string[] | undefined }
   loginWithUsername: false | LoginWithUsernameOptions
+  baseURL?: string
+  basePath?: string
 }
 
 const baseClass = 'admin-signup'
@@ -31,6 +32,8 @@ type SignupFormProps = {
   loginWithUsername: false | LoginWithUsernameOptions
   requireEmailVerification: boolean
   setRequireEmailVerification: React.Dispatch<React.SetStateAction<boolean>>
+  baseURL?: string
+  basePath?: string
 }
 
 const SignupForm: React.FC<SignupFormProps> = ({
@@ -38,7 +41,9 @@ const SignupForm: React.FC<SignupFormProps> = ({
   loginWithUsername,
   requireEmailVerification,
   setRequireEmailVerification,
-  adminInviteToken
+  adminInviteToken,
+  baseURL,
+  basePath
 }) => {
   const {
     config: {
@@ -49,7 +54,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
   } = useConfig()
   const { t } = useTranslation()
   const redirectUrl = getSafeRedirect(searchParams?.redirect as string, adminRoute)
-  const authClient = createAuthClient({ plugins: [usernameClient()] })
+  const authClient = createAuthClient({ baseURL, basePath, plugins: [usernameClient()] })
 
   const requireUsername = Boolean(loginWithUsername && typeof loginWithUsername === 'object' && loginWithUsername.requireUsername)
 
@@ -66,7 +71,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
     },
     onSubmit: async ({ value }) => {
       const { name, email, username, password } = value
-      
+
       const { data, error } = await authClient.signUp.email({
         name,
         email,
@@ -80,7 +85,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
         }
       })
 
-      if((error && error.code === 'EMAIL_NOT_VERIFIED') || (!error && !data.token && !data?.user.emailVerified)) {
+      if ((error && error.code === 'EMAIL_NOT_VERIFIED') || (!error && !data.token && !data?.user.emailVerified)) {
         setRequireEmailVerification(true)
         toast.success('Check your email for a verification link')
         return
@@ -157,7 +162,9 @@ export const AdminSignupClient: React.FC<AdminSignupClientProps> = ({
   userSlug,
   searchParams,
   loginMethods,
-  loginWithUsername
+  loginWithUsername,
+  baseURL,
+  basePath
 }) => {
   const {
     config: {
@@ -178,6 +185,8 @@ export const AdminSignupClient: React.FC<AdminSignupClientProps> = ({
           loginWithUsername={loginWithUsername}
           requireEmailVerification={requireEmailVerification}
           setRequireEmailVerification={setRequireEmailVerification}
+          baseURL={baseURL}
+          basePath={basePath}
         />
       )}
       {!requireEmailVerification && (
@@ -188,6 +197,8 @@ export const AdminSignupClient: React.FC<AdminSignupClientProps> = ({
           setLoading={() => {}}
           redirectUrl={redirectUrl}
           newUserCallbackURL={setAdminRoleCallbackURL}
+          baseURL={baseURL}
+          basePath={basePath}
         />
       )}
     </>

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/admin-signup/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/admin-signup/index.tsx
@@ -93,6 +93,8 @@ const AdminSignup: React.FC<AdminSignupProps> = async ({
             loginMethods={loginMethods}
             searchParams={searchParams ?? {}}
             loginWithUsername={canLoginWithUsername}
+            baseURL={pluginOptions.betterAuthOptions?.baseURL}
+            basePath={pluginOptions.betterAuthOptions?.basePath}
           />
         )
       )}

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/forgot-password/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/forgot-password/client.tsx
@@ -11,14 +11,17 @@ import { toast, useConfig, useTranslation } from '@payloadcms/ui'
 import type { FC } from 'react'
 import { z } from 'zod'
 
-type ForgotPasswordFormProps = {}
+type ForgotPasswordFormProps = {
+  baseURL?: string
+  basePath?: string
+}
 
-export const ForgotPasswordForm: FC<ForgotPasswordFormProps> = () => {
+export const ForgotPasswordForm: FC<ForgotPasswordFormProps> = ({ baseURL, basePath }) => {
   const { t } = useTranslation()
   const { config } = useConfig()
   const adminRoute = config.routes.admin
   const [hasSubmitted, setHasSubmitted] = useState<boolean>(false)
-  const authClient = useMemo(() => createAuthClient(), [])
+  const authClient = useMemo(() => createAuthClient({ baseURL, basePath }), [])
 
   const forgotSchema = z.object({
     email: z.string().refine(
@@ -66,8 +69,7 @@ export const ForgotPasswordForm: FC<ForgotPasswordFormProps> = () => {
       onSubmit={(e) => {
         e.preventDefault()
         void form.handleSubmit()
-      }}
-    >
+      }}>
       <FormHeader heading={t('authentication:forgotPassword')} description={t('authentication:forgotPasswordEmailInstructions')} />
       <FormInputWrap>
         <form.AppField

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/forgot-password/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/forgot-password/index.tsx
@@ -7,8 +7,12 @@ import { formatAdminURL } from 'payload/shared'
 import { FormHeader } from '@/shared/form/ui/header'
 import { ForgotPasswordForm } from './client'
 import { adminRoutes } from '@/better-auth/plugin/constants'
+import type { BetterAuthPluginOptions } from '@/better-auth/plugin/types'
+type ForgotPasswordProps = AdminViewServerProps & {
+  pluginOptions: BetterAuthPluginOptions
+}
 
-const ForgotPassword: React.FC<AdminViewServerProps> = ({ initPageResult }) => {
+const ForgotPassword: React.FC<ForgotPasswordProps> = ({ pluginOptions, initPageResult }) => {
   const {
     req: {
       payload: {
@@ -57,7 +61,7 @@ const ForgotPassword: React.FC<AdminViewServerProps> = ({ initPageResult }) => {
 
   return (
     <MinimalTemplate>
-      <ForgotPasswordForm />
+      <ForgotPasswordForm baseURL={pluginOptions.betterAuthOptions?.baseURL} basePath={pluginOptions.betterAuthOptions?.basePath} />
       <Link
         href={formatAdminURL({
           adminRoute,

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/reset-password/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/reset-password/client.tsx
@@ -14,13 +14,15 @@ type PasswordResetFormArgs = {
   readonly token: string
   readonly minPasswordLength?: number
   readonly maxPasswordLength?: number
+  readonly baseURL?: string
+  readonly basePath?: string
 }
 
-export const PasswordResetForm: React.FC<PasswordResetFormArgs> = ({ token }) => {
+export const PasswordResetForm: React.FC<PasswordResetFormArgs> = ({ token, baseURL, basePath }) => {
   const { t } = useTranslation()
   const history = useRouter()
   const { fetchFullUser } = useAuth()
-  const authClient = useMemo(() => createAuthClient(), [])
+  const authClient = useMemo(() => createAuthClient({ baseURL, basePath }), [])
   const {
     config: {
       admin: {

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/reset-password/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/reset-password/index.tsx
@@ -9,6 +9,7 @@ import { z } from 'zod'
 import { FormHeader } from '@/shared/form/ui/header'
 import { PasswordResetForm } from './client'
 import { adminRoutes } from '@/better-auth/plugin/constants'
+import type { BetterAuthPluginOptions } from '@/better-auth/plugin/types'
 
 const resetPasswordParamsSchema = z.object({
   token: z.string()
@@ -16,7 +17,11 @@ const resetPasswordParamsSchema = z.object({
 
 const resetPasswordBaseClass = 'reset-password'
 
-const ResetPassword: React.FC<AdminViewServerProps> = ({ initPageResult, searchParams }) => {
+type ResetPasswordProps = AdminViewServerProps & {
+  pluginOptions: BetterAuthPluginOptions
+}
+
+const ResetPassword: React.FC<ResetPasswordProps> = ({ pluginOptions, initPageResult, searchParams }) => {
   const {
     req: {
       user,
@@ -45,8 +50,7 @@ const ResetPassword: React.FC<AdminViewServerProps> = ({ initPageResult, searchP
                       adminRoute,
                       path: accountRoute
                     })}
-                    prefetch={false}
-                  >
+                    prefetch={false}>
                     {children}
                   </Link>
                 )
@@ -73,14 +77,17 @@ const ResetPassword: React.FC<AdminViewServerProps> = ({ initPageResult, searchP
   return (
     <MinimalTemplate className={`${resetPasswordBaseClass}`}>
       <FormHeader heading={t('authentication:resetPassword')} />
-      <PasswordResetForm token={token} />
+      <PasswordResetForm
+        token={token}
+        baseURL={pluginOptions.betterAuthOptions?.baseURL}
+        basePath={pluginOptions.betterAuthOptions?.basePath}
+      />
       <Link
         href={formatAdminURL({
           adminRoute,
           path: adminRoutes.adminLogin as `/${string}`
         })}
-        prefetch={false}
-      >
+        prefetch={false}>
         {t('authentication:backToLogin')}
       </Link>
     </MinimalTemplate>

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/two-factor-verify/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/two-factor-verify/client.tsx
@@ -10,10 +10,20 @@ import { toast, useTranslation } from '@payloadcms/ui'
 import { z } from 'zod'
 import { useRouter } from 'next/navigation'
 
-export const TwoFactorVerifyForm = ({ redirect, twoFactorDigits = 6 }: { redirect: string; twoFactorDigits?: number }) => {
+export const TwoFactorVerifyForm = ({
+  redirect,
+  twoFactorDigits = 6,
+  baseURL,
+  basePath
+}: {
+  redirect: string
+  twoFactorDigits?: number
+  baseURL?: string
+  basePath?: string
+}) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const authClient = useMemo(() => createAuthClient({ plugins: [twoFactorClient()] }), [])
+  const authClient = useMemo(() => createAuthClient({ baseURL, basePath, plugins: [twoFactorClient()] }), [])
 
   const otpSchema = z.object({
     code: z

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/two-factor-verify/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/two-factor-verify/index.tsx
@@ -56,7 +56,12 @@ const TwoFactorVerify: React.FC<TwoFactorVerifyProps> = async ({ searchParams, i
 
   return (
     <MinimalTemplate className="two-factor-verify">
-      <TwoFactorVerifyForm redirect={redirectUrl} twoFactorDigits={twoFactorOptions?.totpOptions?.digits} />
+      <TwoFactorVerifyForm
+        redirect={redirectUrl}
+        twoFactorDigits={twoFactorOptions?.totpOptions?.digits}
+        baseURL={pluginOptions.betterAuthOptions?.baseURL}
+        basePath={pluginOptions.betterAuthOptions?.basePath}
+      />
     </MinimalTemplate>
   )
 }


### PR DESCRIPTION
There are multiple places in the code that use BA's `createAuthClient` that do not pass in the base URL or path specified in the options. This means if you use a non-standard API path such as `/api/v1/auth` the plugin breaks due to trying to connect to an invalid URL.

This PR ensures these values are always passed through each time a client is created.

An alternative approach would be to have a centralised authClient rather than loading the BA one each time, so there's no need to pass the values through each time, but as it's being initialised with different properties in different places, there's a few more design considerations involved in any refactoring, so I've kept it simple for now.

Side note - it's supposed to be possible to configure BA by setting an env var, but this didn't seem to be working for me. In any case, even if that's an option, the plugin should either use baseURL/path consistently or not allow you to set it at all.