### PR TITLE
fix: only return after all hooks

### DIFF
--- a/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/admin-login/client.tsx
@@ -70,11 +70,6 @@ const LoginForm: React.FC<{
     if (canLoginWithUsername && hasUsernamePlugin) return 'username'
     return 'email'
   }, [canLoginWithEmail, canLoginWithUsername, hasUsernamePlugin])
-  const [requireEmailVerification, setRequireEmailVerification] = useState<boolean>(false)
-
-  if (requireEmailVerification) {
-    return <FormHeader heading="Please verify your email" description={t('authentication:emailSent')} style={{ textAlign: 'center' }} />
-  }
 
   const loginSchema = createLoginSchema({ t, loginType, canLoginWithUsername })
 
@@ -110,6 +105,12 @@ const LoginForm: React.FC<{
       onSubmit: loginSchema
     }
   })
+
+  const [requireEmailVerification, setRequireEmailVerification] = useState<boolean>(false)
+
+  if (requireEmailVerification) {
+    return <FormHeader heading="Please verify your email" description={t('authentication:emailSent')} style={{ textAlign: 'center' }} />
+  }
 
   const getLoginTypeLabel = () => {
     const labels = {


### PR DESCRIPTION
Fixes a race condition where LoginForm sometimes returns before all its hooks have run which leads to a React error.