### PR TITLE
fix: two factor

### DIFF
--- a/packages/payload-auth/src/better-auth/plugin/helpers/get-collection.ts
+++ b/packages/payload-auth/src/better-auth/plugin/helpers/get-collection.ts
@@ -30,6 +30,5 @@ export function getCollectionFieldNameByFieldKey<M extends ModelKey>(
   fieldKey: Extract<keyof BetterAuthFullSchema[M], string>
 ): string {
   const fields = flattenAllFields({ fields: collection.fields })
-  console.log('fields', fields)
   return fields.find((f) => f.custom?.betterAuthFieldKey === fieldKey)?.name ?? fieldKey
 }

--- a/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/organizations-plugin.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/organizations-plugin.ts
@@ -8,14 +8,19 @@ export function configureOrganizationPlugin(plugin: any, resolvedSchemas: Better
   models.forEach((model) => set(plugin, `schema.${model}.modelName`, getSchemaCollectionSlug(resolvedSchemas, model)))
 
   set(plugin, `schema.${baModelKey.member}.fields.organizationId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.member, baModelFieldKeys.member.organizationId))
+  set(plugin, `schema.${baModelKey.member}.fields.organizationId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.organization))
   set(plugin, `schema.${baModelKey.member}.fields.userId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.member, baModelFieldKeys.member.userId))
+  set(plugin, `schema.${baModelKey.member}.fields.userId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
   set(plugin, `schema.${baModelKey.member}.fields.teamId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.member, baModelFieldKeys.member.teamId))
 
   set(plugin, `schema.${baModelKey.invitation}.fields.organizationId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.invitation, baModelFieldKeys.invitation.organizationId))
+  set(plugin, `schema.${baModelKey.invitation}.fields.organizationId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.organization))
   set(plugin, `schema.${baModelKey.invitation}.fields.inviterId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.invitation, baModelFieldKeys.invitation.inviterId))
+  set(plugin, `schema.${baModelKey.invitation}.fields.inviterId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
   set(plugin, `schema.${baModelKey.invitation}.fields.teamId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.invitation, baModelFieldKeys.invitation.teamId))
-
+  
   set(plugin, `schema.${baModelKey.team}.fields.organizationId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.team, baModelFieldKeys.team.organizationId))
-
+  set(plugin, `schema.${baModelKey.team}.fields.organizationId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
+  
   set(plugin, `schema.${baModelKey.session}.fields.activeOrganizationId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.session, baModelFieldKeys.session.activeOrganizationId))
 }

--- a/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/passkey-plugin.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/passkey-plugin.ts
@@ -7,4 +7,5 @@ export function configurePasskeyPlugin(plugin: any, resolvedSchemas: BetterAuthS
   const model = baModelKey.passkey
   set(plugin, `schema.${model}.modelName`, getSchemaCollectionSlug(resolvedSchemas, model))
   set(plugin, `schema.${model}.fields.userId.fieldName`, getSchemaFieldName(resolvedSchemas, model, baModelFieldKeys.passkey.userId))
+  set(plugin, `schema.${model}.fields.userId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
 }

--- a/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/two-factor-plugin.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/two-factor-plugin.ts
@@ -7,4 +7,5 @@ export function configureTwoFactorPlugin(plugin: any, resolvedSchemas: BetterAut
   const model = baModelKey.twoFactor
   set(plugin, `schema.${model}.modelName`, getSchemaCollectionSlug(resolvedSchemas, model))
   set(plugin, `schema.${model}.fields.userId.fieldName`, getSchemaFieldName(resolvedSchemas, model, baModelFieldKeys.twoFactor.userId))
+  set(plugin, `schema.${model}.fields.userId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
 }

--- a/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/utils/save-to-jwt-middleware.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/utils/save-to-jwt-middleware.ts
@@ -43,6 +43,10 @@ export function saveToJwtMiddleware({
 
       if (filteredSessionData) {
         await setSessionCookie(ctx, filteredSessionData)
+        // Set back all the data internally as we only want the cookie to update.
+        // This allows plugins like two factor plugin to get enabledTwoFactor,
+        // while not exposing it in cookie cache data.
+        ctx.context.setNewSession(newSession)
       }
     }
 

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/two-factor-verify/client.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/two-factor-verify/client.tsx
@@ -29,7 +29,7 @@ export const TwoFactorVerifyForm = ({
     code: z
       .string()
       .length(twoFactorDigits, `Code must be ${twoFactorDigits} digits`)
-      .refine((val) => /^\d{${twoFactorDigits}}$/.test(val), `Code must be numeric`)
+      .refine((val) => /^\d{6}$/.test(val), 'Code must be numeric')
   })
 
   const form = useAppForm({


### PR DESCRIPTION
Adding missing model references in plugin configurators, removing unnecessary console logs, and importantly, fixing the two-factor authentication view.

The issue with the two-factor view occurred because saveToJwtMiddleware was executed before calls to the BetterAuth sign-in API. This caused the twoFactorEnabled property to be omitted from theuser object.