### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug Report
+about: Report a reproducible issue with this project
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        Please complete the fields below to help us reproduce and fix the issue more quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps To Reproduce
+      description: |
+        Provide step-by-step instructions for how to reproduce the issue.
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Tell us about your environment. Include versions where applicable.
+      placeholder: |
+        Payload Auth version:
+        Payload version:
+        Node version:
+        Database type and version:
+        OS:
+    validations:
+      required: true
+
+  - type: input
+    id: reproduction-url
+    attributes:
+      label: Reproduction URL (optional)
+      description: |
+        If you have a minimal reproduction repository or URL, please link it here. This helps us troubleshoot faster.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, logs, or screenshots about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+about: Suggest an idea or enhancement for this project
+labels: enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing an idea to improve this project!
+        Please answer the questions below so we can better understand your request.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Explain the problem this feature would solve or the use case it enables.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- add a bug report template requiring description, steps and environment details
- add a feature request template
- disable blank issues and link to documentation

## Testing
- `pnpm --filter ./packages/payload-auth test` *(fails: Vitest unhandled errors)*
