### PR TITLE
Update Better Auth and Payload and make the plugin RSC safe

### DIFF
--- a/packages/payload-auth/package.json
+++ b/packages/payload-auth/package.json
@@ -79,19 +79,19 @@
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
     "build:types": "pnpm generate:better-auth-types && tsc --project tsconfig.json",
     "test": "vitest",
-    "generate:better-auth-types": "rm -rf src/better-auth/generated-types.ts && tsx src/better-auth/scripts/generate-types.ts"
+    "generate:better-auth-types": "tsx src/better-auth/scripts/generate-types.ts"
   },
   "peerDependencies": {
-    "@payloadcms/ui": "^3.35",
-    "better-auth": "^1.2",
+    "@payloadcms/ui": ">=3.55.1 <4",
+    "better-auth": ">=1.3.11 <2",
     "next": "^15.3.0",
-    "payload": "^3.35",
+    "payload": ">=3.55.1 <4",
     "react": "^19",
     "react-dom": "^19"
   },
   "devDependencies": {
     "@clerk/types": "^4.50.1",
-    "@payloadcms/db-postgres": "3.35.1",
+    "@payloadcms/db-postgres": "^3.55.1",
     "@swc/cli": "0.6.0",
     "@swc/core": "1.11.13",
     "@types/node": "^20.0.0",
@@ -100,7 +100,6 @@
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
     "dotenv": "^16.5.0",
-    "payload": "^3.35",
     "tsx": "^4.19.4",
     "typescript": "5.8.2",
     "vitest": "^1.0.0"

--- a/packages/payload-auth/src/better-auth/adapter/types.ts
+++ b/packages/payload-auth/src/better-auth/adapter/types.ts
@@ -1,10 +1,14 @@
 import type { AdapterInstance } from 'better-auth'
 import type { BasePayload } from 'payload'
 
-export type PayloadAdapterParams = {
-  payloadClient: BasePayload | Promise<BasePayload> | (() => Promise<BasePayload>);
-  enableDebugLogs?: boolean;
-  idType: 'number' | 'text';
+export interface PayloadAdapterParams {
+  payloadClient: BasePayload | Promise<BasePayload> | (() => Promise<BasePayload>)
+  adapterConfig?: {
+    enableDebugLogs?: boolean
+    idType: 'number' | 'text'
+  }
+  enableDebugLogs?: boolean
+  idType?: 'number' | 'text'
 }
 
 export type PayloadAdapter = (options: PayloadAdapterParams) => AdapterInstance

--- a/packages/payload-auth/src/better-auth/generated-types.ts
+++ b/packages/payload-auth/src/better-auth/generated-types.ts
@@ -56,6 +56,7 @@ export type SessionPluginFields = {
   }
   "organization": {
     activeOrganizationId?: string
+    activeTeamId?: string
   }
 }
 
@@ -82,8 +83,8 @@ export type BaseVerificationFields = {
   identifier: string
   value: string
   expiresAt: Date
-  createdAt?: Date
-  updatedAt?: Date
+  createdAt: Date
+  updatedAt: Date
 }
 
 export type Verification = BaseVerificationFields
@@ -123,6 +124,7 @@ export type PasskeyFields = {
   backedUp: boolean
   transports?: string
   createdAt?: Date
+  aaguid?: string
 }
 
 export type Passkey = PasskeyFields
@@ -180,6 +182,23 @@ export type SsoProviderFields = {
 
 export type SsoProvider = SsoProviderFields
 
+export type TeamFields = {
+  name: string
+  organizationId: string
+  createdAt: Date
+  updatedAt?: Date
+}
+
+export type Team = TeamFields
+
+export type TeamMemberFields = {
+  teamId: string
+  userId: string
+  createdAt?: Date
+}
+
+export type TeamMember = TeamMemberFields
+
 export type OrganizationFields = {
   name: string
   slug?: string
@@ -194,7 +213,6 @@ export type MemberFields = {
   organizationId: string
   userId: string
   role: string
-  teamId?: string
   createdAt: Date
 }
 
@@ -211,15 +229,6 @@ export type InvitationFields = {
 }
 
 export type Invitation = InvitationFields
-
-export type TeamFields = {
-  name: string
-  organizationId: string
-  createdAt: Date
-  updatedAt?: Date
-}
-
-export type Team = TeamFields
 
 export type JwksFields = {
   publicKey: string
@@ -264,10 +273,11 @@ export type BetterAuthFullSchema = {
   "oauthAccessToken": OauthAccessToken
   "oauthConsent": OauthConsent
   "ssoProvider": SsoProvider
+  "team": Team
+  "teamMember": TeamMember
   "organization": Organization
   "member": Member
   "invitation": Invitation
-  "team": Team
   "jwks": Jwks
   "twoFactor": TwoFactor
   "subscription": Subscription

--- a/packages/payload-auth/src/better-auth/plugin/constants.ts
+++ b/packages/payload-auth/src/better-auth/plugin/constants.ts
@@ -100,6 +100,7 @@ export const baModelKey = {
   invitation: 'invitation',
   member: 'member',
   team: 'team',
+  teamMember: 'teamMember',
   subscription: 'subscription',
   apikey: 'apikey',
   jwks: 'jwks'
@@ -216,6 +217,7 @@ export const baModelKeyToSlug = {
   invitation: baPluginSlugs.invitations,
   member: baPluginSlugs.members,
   team: baPluginSlugs.teams,
+  teamMember: 'teamMembers',
   subscription: baPluginSlugs.subscriptions,
   apikey: baPluginSlugs.apiKeys,
   jwks: baPluginSlugs.jwks

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/accounts/index.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/accounts/index.ts
@@ -30,7 +30,7 @@ export function buildAccountsCollection({ incomingCollections, pluginOptions, re
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/api-keys.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/api-keys.ts
@@ -86,7 +86,7 @@ export function buildApiKeysCollection({ incomingCollections, pluginOptions, res
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/oauth-access-tokens.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/oauth-access-tokens.ts
@@ -57,7 +57,7 @@ export function buildOauthAccessTokensCollection({
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/oauth-applications.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/oauth-applications.ts
@@ -67,7 +67,7 @@ export function buildOauthApplicationsCollection({
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/oauth-consents.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/oauth-consents.ts
@@ -49,7 +49,7 @@ export function buildOauthConsentsCollection({
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/sessions.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/sessions.ts
@@ -73,7 +73,7 @@ export function buildSessionsCollection({ incomingCollections, pluginOptions, re
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/team-members.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/team-members.ts
@@ -1,0 +1,60 @@
+import { baModelKey } from '../../constants'
+import { getAdminAccess } from '../../helpers/get-admin-access'
+import { getCollectionFields } from './utils/transform-schema-fields-to-payload'
+import { getSchemaCollectionSlug, getSchemaFieldName, assertAllSchemaFields } from './utils/collection-schema'
+
+import type { CollectionConfig } from 'payload'
+import type { BuildCollectionProps, FieldOverrides } from '@/better-auth/plugin/types'
+import type { TeamMember } from '@/better-auth/generated-types'
+
+export function buildTeamMembersCollection({ incomingCollections, pluginOptions, resolvedSchemas }: BuildCollectionProps): CollectionConfig {
+  const teamMemberSlug = getSchemaCollectionSlug(resolvedSchemas as any, (baModelKey as any).teamMember)
+  const teamMemberSchema = (resolvedSchemas as any)[(baModelKey as any).teamMember]
+
+  const existingTeamMemberCollection = incomingCollections.find((collection) => collection.slug === teamMemberSlug) as
+    | CollectionConfig
+    | undefined
+
+  const fieldOverrides: FieldOverrides<keyof TeamMember> = {
+    teamId: () => ({
+      index: true,
+      admin: { readOnly: true, description: 'The team that the membership belongs to.' }
+    }),
+    userId: () => ({
+      index: true,
+      admin: { readOnly: true, description: 'The user that is a member of the team.' }
+    })
+  }
+
+  const collectionFields = getCollectionFields({
+    schema: teamMemberSchema,
+    additionalProperties: fieldOverrides
+  })
+
+  let teamMemberCollection: CollectionConfig = {
+    ...existingTeamMemberCollection,
+    slug: teamMemberSlug,
+    admin: {
+      hidden: pluginOptions.hidePluginCollections ?? false,
+      useAsTitle: getSchemaFieldName(resolvedSchemas, baModelKey.teamMember as any, 'teamId' as any),
+      description: 'Team members of an organization team.',
+      group: pluginOptions?.collectionAdminGroup ?? 'Auth',
+      ...existingTeamMemberCollection?.admin
+    },
+    access: {
+      ...getAdminAccess(pluginOptions),
+      ...(existingTeamMemberCollection?.access ?? {})
+    },
+    custom: {
+      ...(existingTeamMemberCollection?.custom ?? {}),
+      betterAuthModelKey: baModelKey.teamMember as any
+    },
+    fields: [...(existingTeamMemberCollection?.fields ?? []), ...(collectionFields ?? [])]
+  }
+
+  assertAllSchemaFields(teamMemberCollection, teamMemberSchema)
+
+  return teamMemberCollection
+}
+
+

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/teams.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/teams.ts
@@ -36,7 +36,7 @@ export function buildTeamsCollection({ incomingCollections, pluginOptions, resol
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/users/endpoints/refresh-token.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/users/endpoints/refresh-token.ts
@@ -98,7 +98,7 @@ export const getRefreshTokenEndpoint = (userSlug: string): Endpoint => {
       await setCookieCache(ctx, {
         session: res.session,
         user: cookieCacheFields as any
-      })
+      }, false)
 
       return response
     }

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/users/index.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/users/index.ts
@@ -34,6 +34,11 @@ export function buildUsersCollection({ incomingCollections, pluginOptions, resol
   // TODO: REVIEW THIS
   const allowedFields = pluginOptions.users?.allowedFields ?? ['name']
 
+  const showAdminButtonsTab = checkPluginExists(
+    pluginOptions.betterAuthOptions ?? {},
+    supportedBAPluginIds.admin
+  )
+
   const userFieldRules: FieldRule[] = [
     {
       condition: (field) => field.fieldName === 'createdAt' || field.fieldName === 'updatedAt',
@@ -45,7 +50,7 @@ export function buildUsersCollection({ incomingCollections, pluginOptions, resol
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => (field.fieldName === 'createdAt' ? t('general:createdAt') : t('general:updatedAt'))
+        label: field.fieldName === 'createdAt' ? 'general:createdAt' : 'general:updatedAt'
       })
     }
   ]
@@ -151,22 +156,22 @@ export function buildUsersCollection({ incomingCollections, pluginOptions, resol
         },
         views: {
           edit: {
-            adminButtons: {
-              tab: {
-                Component: {
-                  path: 'payload-auth/better-auth/plugin/client#AdminButtons',
-                  clientProps: {
-                    userSlug,
-                    baseURL: pluginOptions.betterAuthOptions?.baseURL,
-                    basePath: pluginOptions.betterAuthOptions?.basePath
+            ...(showAdminButtonsTab
+              ? {
+                  adminButtons: {
+                    tab: {
+                      Component: {
+                        path: 'payload-auth/better-auth/plugin/client#AdminButtons',
+                        clientProps: {
+                          userSlug,
+                          baseURL: pluginOptions.betterAuthOptions?.baseURL,
+                          basePath: pluginOptions.betterAuthOptions?.basePath
+                        }
+                      }
+                    }
                   }
-                },
-                condition: () => {
-                  // Only show the impersonate button if the admin plugin is enabled
-                  return checkPluginExists(pluginOptions.betterAuthOptions ?? {}, supportedBAPluginIds.admin)
                 }
-              }
-            }
+              : {})
           }
         }
       }

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/utils/get-timestamp-fields.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/utils/get-timestamp-fields.ts
@@ -21,7 +21,7 @@ export function getTimestampFields(
         hidden: true
       },
       index: true,
-      label: ({ t }) => t('general:updatedAt')
+      label: 'general:updatedAt'
     },
     {
       name: 'createdAt',
@@ -32,7 +32,7 @@ export function getTimestampFields(
       },
       type: 'date',
       index: true,
-      label: ({ t }) => t('general:createdAt')
+      label: 'general:createdAt'
     }
   ]
 }

--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/verifications.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/verifications.ts
@@ -49,7 +49,7 @@ export function buildVerificationsCollection({ incomingCollections, pluginOption
           hidden: true
         },
         index: true,
-        label: ({ t }: any) => t('general:updatedAt')
+        label: 'general:updatedAt'
       })
     }
   ]

--- a/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/organizations-plugin.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/organizations-plugin.ts
@@ -11,16 +11,21 @@ export function configureOrganizationPlugin(plugin: any, resolvedSchemas: Better
   set(plugin, `schema.${baModelKey.member}.fields.organizationId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.organization))
   set(plugin, `schema.${baModelKey.member}.fields.userId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.member, baModelFieldKeys.member.userId))
   set(plugin, `schema.${baModelKey.member}.fields.userId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
-  set(plugin, `schema.${baModelKey.member}.fields.teamId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.member, baModelFieldKeys.member.teamId))
+  if ((resolvedSchemas as any)?.member?.fields?.teamId) {
+    set(plugin, `schema.${baModelKey.member}.fields.teamId.fieldName`, getSchemaFieldName(resolvedSchemas as any, baModelKey.member as any, (baModelFieldKeys as any).member.teamId))
+  }
 
   set(plugin, `schema.${baModelKey.invitation}.fields.organizationId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.invitation, baModelFieldKeys.invitation.organizationId))
   set(plugin, `schema.${baModelKey.invitation}.fields.organizationId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.organization))
   set(plugin, `schema.${baModelKey.invitation}.fields.inviterId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.invitation, baModelFieldKeys.invitation.inviterId))
   set(plugin, `schema.${baModelKey.invitation}.fields.inviterId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
-  set(plugin, `schema.${baModelKey.invitation}.fields.teamId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.invitation, baModelFieldKeys.invitation.teamId))
+  // Guard for older versions without teamId in invitation
+  if ((resolvedSchemas as any)?.invitation?.fields?.teamId) {
+    set(plugin, `schema.${baModelKey.invitation}.fields.teamId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.invitation, baModelFieldKeys.invitation.teamId))
+  }
   
   set(plugin, `schema.${baModelKey.team}.fields.organizationId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.team, baModelFieldKeys.team.organizationId))
-  set(plugin, `schema.${baModelKey.team}.fields.organizationId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.user))
+  set(plugin, `schema.${baModelKey.team}.fields.organizationId.references.model`, getSchemaCollectionSlug(resolvedSchemas, baModelKey.organization))
   
   set(plugin, `schema.${baModelKey.session}.fields.activeOrganizationId.fieldName`, getSchemaFieldName(resolvedSchemas, baModelKey.session, baModelFieldKeys.session.activeOrganizationId))
 }

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/forgot-password/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/forgot-password/index.tsx
@@ -47,7 +47,7 @@ const ForgotPassword: React.FC<ForgotPasswordProps> = ({ pluginOptions, initPage
                 )
               }}
               i18nKey="authentication:loggedInChangePassword"
-              t={i18n.t}
+              t={i18n.t as any}
             />
           }
           heading={i18n.t('authentication:alreadyLoggedIn')}

--- a/packages/payload-auth/src/better-auth/plugin/payload/views/reset-password/index.tsx
+++ b/packages/payload-auth/src/better-auth/plugin/payload/views/reset-password/index.tsx
@@ -56,7 +56,7 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ pluginOptions, initPageRe
                 )
               }}
               i18nKey="authentication:loggedInChangePassword"
-              t={t}
+              t={t as any}
             />
           }
           heading={t('authentication:alreadyLoggedIn')}

--- a/packages/payload-auth/src/better-auth/scripts/generate-types.ts
+++ b/packages/payload-auth/src/better-auth/scripts/generate-types.ts
@@ -1,6 +1,7 @@
 import { stripe } from '@better-auth/stripe'
 import { emailHarmony, phoneHarmony } from 'better-auth-harmony'
-import { getSchema } from 'better-auth/db'
+// Dynamic import to avoid type coupling between minor versions
+const getSchema: (opts: any) => any = (await import('better-auth/db')).getSchema as any
 import type { FieldAttribute } from 'better-auth/db'
 import {
   admin,
@@ -37,7 +38,7 @@ const client = new Polar({
   server: 'sandbox'
 });
 
-const plugins = [
+const plugins: any[] = [
   username(),
   admin(),
   apiKey(),
@@ -91,7 +92,7 @@ const plugins = [
 const betterAuthConfig: SanitizedBetterAuthOptions = {
   emailAndPassword: { enabled: true },
   user: { additionalFields: { role: { type: 'string', defaultValue: 'user', input: false } } },
-  plugins
+  plugins: plugins
 }
 
 const baseSchema = getSchema({ ...betterAuthConfig, plugins: [] })
@@ -150,7 +151,7 @@ const gen = (): string => {
 
     if (Object.keys(base).length) {
       out += `export type Base${P}Fields = {\n`
-      for (const [k, f] of Object.entries(base)) out += `  ${f.fieldName ?? k}${f.required ? '' : '?'}: ${map(f.type as string)}\n`
+      for (const [k, f] of Object.entries(base as Record<string, any>)) out += `  ${(f as any).fieldName ?? k}${(f as any).required ? '' : '?'}: ${map((f as any).type as string)}\n`
       out += '}\n\n'
     }
 
@@ -159,7 +160,7 @@ const gen = (): string => {
       out += `export type ${P}PluginFields = {\n`
       for (const [pid, flds] of Object.entries(pluginsForModel)) {
         out += `  ${JSON.stringify(pid)}: {\n`
-        for (const [k, f] of Object.entries(flds)) out += `    ${f.fieldName ?? k}${f.required ? '' : '?'}: ${map(f.type as string)}\n`
+        for (const [k, f] of Object.entries(flds as Record<string, any>)) out += `    ${(f as any).fieldName ?? k}${(f as any).required ? '' : '?'}: ${map((f as any).type as string)}\n`
         out += '  }\n'
       }
       out += '}\n\n'
@@ -168,8 +169,8 @@ const gen = (): string => {
     if (!Object.keys(base).length && pluginIds.length === 1) {
       const only = pluginIds[0]
       out += `export type ${P}Fields = {\n`
-      for (const [k, f] of Object.entries(pluginsForModel[only]))
-        out += `  ${f.fieldName ?? k}${f.required ? '' : '?'}: ${map(f.type as string)}\n`
+      for (const [k, f] of Object.entries(pluginsForModel[only] as Record<string, any>))
+        out += `  ${(f as any).fieldName ?? k}${(f as any).required ? '' : '?'}: ${map((f as any).type as string)}\n`
       out += '}\n\n'
       out += `export type ${P} = ${P}Fields\n\n`
       continue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 3.35.1(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
       '@payloadcms/db-vercel-postgres':
         specifier: 3.35.1
-        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
+        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
       '@payloadcms/next':
         specifier: 3.35.1
         version: 3.35.1(@types/react@19.1.2)(graphql@16.11.0)(monaco-editor@0.52.2)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
@@ -432,7 +432,7 @@ importers:
         version: 3.35.1(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
       '@payloadcms/db-postgres':
         specifier: 3.35.1
-        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
+        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
       '@payloadcms/next':
         specifier: 3.35.1
         version: 3.35.1(@types/react@19.0.10)(graphql@16.11.0)(monaco-editor@0.52.2)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
@@ -499,7 +499,7 @@ importers:
         version: 3.35.1(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
       '@payloadcms/db-vercel-postgres':
         specifier: 3.35.1
-        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
+        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
       '@payloadcms/next':
         specifier: 3.35.1
         version: 3.35.1(@types/react@19.1.2)(graphql@16.11.0)(monaco-editor@0.52.2)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
@@ -668,7 +668,7 @@ importers:
         version: 3.35.1(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
       '@payloadcms/db-postgres':
         specifier: 3.35.1
-        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
+        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
       '@payloadcms/next':
         specifier: 3.35.1
         version: 3.35.1(@types/react@19.0.10)(graphql@16.11.0)(monaco-editor@0.52.2)(next@15.3.0(babel-plugin-react-compiler@19.0.0-beta-e993439-20250328)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
@@ -771,7 +771,7 @@ importers:
         version: 3.35.1(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
       '@payloadcms/db-postgres':
         specifier: 3.35.1
-        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
+        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
       '@payloadcms/next':
         specifier: 3.35.1
         version: 3.35.1(@types/react@19.0.10)(graphql@16.11.0)(monaco-editor@0.52.2)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
@@ -832,7 +832,7 @@ importers:
     dependencies:
       '@better-auth/stripe':
         specifier: 1.2.7
-        version: 1.2.7
+        version: 1.2.7(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@better-auth/utils':
         specifier: 0.2.4
         version: 0.2.4
@@ -847,19 +847,19 @@ importers:
         version: 6.18.5(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(svix@1.64.1)
       '@payloadcms/ui':
         specifier: ^3.35
-        version: 3.35.1(@types/react@19.1.2)(monaco-editor@0.52.2)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
+        version: 3.35.1(@types/react@19.1.2)(monaco-editor@0.52.2)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)
       '@polar-sh/better-auth':
         specifier: ^0.1.1
-        version: 0.1.1(@polar-sh/sdk@0.32.13(zod@3.24.3))(better-auth@1.2.7)
+        version: 0.1.1(@polar-sh/sdk@0.32.13(zod@4.1.8))(better-auth@1.3.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@polar-sh/sdk':
         specifier: ^0.32.13
-        version: 0.32.13(zod@3.24.3)
+        version: 0.32.13(zod@4.1.8)
       '@tanstack/react-form':
         specifier: 1.4.0
         version: 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       better-auth:
-        specifier: ^1.2
-        version: 1.2.7
+        specifier: '>=1.3.11 <2'
+        version: 1.3.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -875,6 +875,9 @@ importers:
       next:
         specifier: ^15.3.0
         version: 15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+      payload:
+        specifier: '>=3.55.1 <4'
+        version: 3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.1.0)
@@ -901,8 +904,8 @@ importers:
         specifier: ^4.50.1
         version: 4.56.3
       '@payloadcms/db-postgres':
-        specifier: 3.35.1
-        version: 3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)
+        specifier: ^3.55.1
+        version: 3.55.1(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
       '@swc/cli':
         specifier: 0.6.0
         version: 0.6.0(@swc/core@1.11.13(@swc/helpers@0.5.17))(chokidar@4.0.3)
@@ -927,9 +930,6 @@ importers:
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
-      payload:
-        specifier: ^3.35
-        version: 3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
       tsx:
         specifier: ^4.19.4
         version: 4.19.4
@@ -996,6 +996,9 @@ packages:
 
   '@better-auth/utils@0.2.4':
     resolution: {integrity: sha512-ayiX87Xd5sCHEplAdeMgwkA0FgnXsEZBgDn890XHHwSWNqqRZDYOq3uj2Ei2leTv1I2KbG5HHn60Ah1i2JWZjQ==}
+
+  '@better-auth/utils@0.3.0':
+    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
 
   '@better-fetch/fetch@1.1.18':
     resolution: {integrity: sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==}
@@ -1271,6 +1274,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -1297,6 +1306,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.3':
     resolution: {integrity: sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1331,6 +1346,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -1357,6 +1378,12 @@ packages:
 
   '@esbuild/android-x64@0.25.3':
     resolution: {integrity: sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1391,6 +1418,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -1417,6 +1450,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.3':
     resolution: {integrity: sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1451,6 +1490,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -1477,6 +1522,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.3':
     resolution: {integrity: sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1511,6 +1562,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -1537,6 +1594,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.3':
     resolution: {integrity: sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1571,6 +1634,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -1597,6 +1666,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.3':
     resolution: {integrity: sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1631,6 +1706,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -1657,6 +1738,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.3':
     resolution: {integrity: sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1691,6 +1778,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -1717,6 +1810,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.3':
     resolution: {integrity: sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1751,8 +1850,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.3':
     resolution: {integrity: sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1787,6 +1898,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
     engines: {node: '>=18'}
@@ -1795,6 +1912,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.3':
     resolution: {integrity: sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1829,6 +1952,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.18.20':
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
@@ -1855,6 +1990,12 @@ packages:
 
   '@esbuild/sunos-x64@0.25.3':
     resolution: {integrity: sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1889,6 +2030,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.18.20':
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
@@ -1919,6 +2066,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -1945,6 +2098,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.3':
     resolution: {integrity: sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2660,9 +2819,17 @@ packages:
   '@noble/ciphers@0.6.0':
     resolution: {integrity: sha512-mIbq/R9QXk5/cTfESb1OKtyFnk7oc1Om/8onA1158K9/OZUQFDEVy55jVTato+xmp3XX6F6Qh0zz0Nc1AxAlRQ==}
 
+  '@noble/ciphers@2.0.0':
+    resolution: {integrity: sha512-j/l6jpnpaIBM87cAYPJzi/6TgqmBv9spkqPyCXvRYsu5uxqh6tPJZDnD85yo8VWqzTuTQPgfv7NgT63u7kbwAQ==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.0.0':
+    resolution: {integrity: sha512-h8VUBlE8R42+XIDO229cgisD287im3kdY6nbNZJFjc6ZvKIXPYXe6Vc/t+kyjFdMFyt5JpapzTsEg8n63w5/lw==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2788,6 +2955,11 @@ packages:
     peerDependencies:
       payload: 3.35.1
 
+  '@payloadcms/db-postgres@3.55.1':
+    resolution: {integrity: sha512-nk/1IpeBABSj+Jjqf+USOHr/6A4uEv/TxsqxMvcpqsj363cioJdLrcnJug3cf+UbWs7Ou7sdeGBZhYpCghdG+g==}
+    peerDependencies:
+      payload: 3.55.1
+
   '@payloadcms/db-vercel-postgres@3.35.1':
     resolution: {integrity: sha512-A25NRwBOObctVoxhqiU1he29I7h+FtlkmCTyQ3iroID2clt2QhOwM/wLA/bx6BSFhb3kbDoNL5NdbUh2pMNMiA==}
     peerDependencies:
@@ -2797,6 +2969,11 @@ packages:
     resolution: {integrity: sha512-udUDqyB+5oNo0Fl3Wxf2YbpPpZfDtYV6tXTS4nqY08G3ic9e7P44AFR/P2JLmsKYTHLViz7GR2tEV1oQYLHnxw==}
     peerDependencies:
       payload: 3.35.1
+
+  '@payloadcms/drizzle@3.55.1':
+    resolution: {integrity: sha512-amI6uU6sy/9i1tS1Kg9hS1l/i0mV3V0Bs3GYvoveOkFQIVdF7uYyI9Q7MG0SXXdD+Ioht/M+XEYId7cUc9zJ/w==}
+    peerDependencies:
+      payload: 3.55.1
 
   '@payloadcms/graphql@3.35.1':
     resolution: {integrity: sha512-lSwbtP81MGdhKSXNOALy5WacH6C0PSy/39NJwsr6SIrsFTOGygccDY4bR1caw3dzkHiDyFCpBLD84LlSb2Zmhw==}
@@ -2827,6 +3004,9 @@ packages:
   '@payloadcms/translations@3.35.1':
     resolution: {integrity: sha512-scp/nl6v/M8VLRjRMpfBlkvaIUnwwoDYiF3KsmReNarBfOzaFsWriUx0xotPS12pszAOpBVVjUqpjbQ9V+ZS5A==}
 
+  '@payloadcms/translations@3.55.1':
+    resolution: {integrity: sha512-iYb0qrx2FNgy3oApsyLJQYzSxip29wPWE+SnN6sW/rllKU8SwFuwOCp/xu994rS3jcBpYQ0Y0EAJ4BqdvJ0dnA==}
+
   '@payloadcms/ui@3.35.1':
     resolution: {integrity: sha512-awAu7wJlLjAc4pDItFvGsJCWL1ZEIxL2NF09B4xoGek+h4/0Y1uXCs6AvCEJMmZUQmu9bZzaJACsF+WBSPTT9Q==}
     engines: {node: ^18.20.2 || >=20.9.0}
@@ -2839,17 +3019,50 @@ packages:
   '@peculiar/asn1-android@2.3.16':
     resolution: {integrity: sha512-a1viIv3bIahXNssrOIkXZIlI2ePpZaNmR30d4aBL99mu2rO+mT9D6zBsp7H6eROWGtmwv0Ionp5olJurIo09dw==}
 
+  '@peculiar/asn1-cms@2.5.0':
+    resolution: {integrity: sha512-p0SjJ3TuuleIvjPM4aYfvYw8Fk1Hn/zAVyPJZTtZ2eE9/MIer6/18ROxX6N/e6edVSfvuZBqhxAj3YgsmSjQ/A==}
+
+  '@peculiar/asn1-csr@2.5.0':
+    resolution: {integrity: sha512-ioigvA6WSYN9h/YssMmmoIwgl3RvZlAYx4A/9jD2qaqXZwGcNlAxaw54eSx2QG1Yu7YyBC5Rku3nNoHrQ16YsQ==}
+
   '@peculiar/asn1-ecc@2.3.15':
     resolution: {integrity: sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==}
+
+  '@peculiar/asn1-ecc@2.5.0':
+    resolution: {integrity: sha512-t4eYGNhXtLRxaP50h3sfO6aJebUCDGQACoeexcelL4roMFRRVgB20yBIu2LxsPh/tdW9I282gNgMOyg3ywg/mg==}
+
+  '@peculiar/asn1-pfx@2.5.0':
+    resolution: {integrity: sha512-Vj0d0wxJZA+Ztqfb7W+/iu8Uasw6hhKtCdLKXLG/P3kEPIQpqGI4P4YXlROfl7gOCqFIbgsj1HzFIFwQ5s20ug==}
+
+  '@peculiar/asn1-pkcs8@2.5.0':
+    resolution: {integrity: sha512-L7599HTI2SLlitlpEP8oAPaJgYssByI4eCwQq2C9eC90otFpm8MRn66PpbKviweAlhinWQ3ZjDD2KIVtx7PaVw==}
+
+  '@peculiar/asn1-pkcs9@2.5.0':
+    resolution: {integrity: sha512-UgqSMBLNLR5TzEZ5ZzxR45Nk6VJrammxd60WMSkofyNzd3DQLSNycGWSK5Xg3UTYbXcDFyG8pA/7/y/ztVCa6A==}
 
   '@peculiar/asn1-rsa@2.3.15':
     resolution: {integrity: sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==}
 
+  '@peculiar/asn1-rsa@2.5.0':
+    resolution: {integrity: sha512-qMZ/vweiTHy9syrkkqWFvbT3eLoedvamcUdnnvwyyUNv5FgFXA3KP8td+ATibnlZ0EANW5PYRm8E6MJzEB/72Q==}
+
   '@peculiar/asn1-schema@2.3.15':
     resolution: {integrity: sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==}
 
+  '@peculiar/asn1-schema@2.5.0':
+    resolution: {integrity: sha512-YM/nFfskFJSlHqv59ed6dZlLZqtZQwjRVJ4bBAiWV08Oc+1rSd5lDZcBEx0lGDHfSoH3UziI2pXt2UM33KerPQ==}
+
+  '@peculiar/asn1-x509-attr@2.5.0':
+    resolution: {integrity: sha512-9f0hPOxiJDoG/bfNLAFven+Bd4gwz/VzrCIIWc1025LEI4BXO0U5fOCTNDPbbp2ll+UzqKsZ3g61mpBp74gk9A==}
+
   '@peculiar/asn1-x509@2.3.15':
     resolution: {integrity: sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==}
+
+  '@peculiar/asn1-x509@2.5.0':
+    resolution: {integrity: sha512-CpwtMCTJvfvYTFMuiME5IH+8qmDe3yEWzKHe7OOADbGfq7ohxeLaXwQo0q4du3qs0AII3UbLCvb9NF/6q0oTKQ==}
+
+  '@peculiar/x509@1.14.0':
+    resolution: {integrity: sha512-Yc4PDxN3OrxUPiXgU63c+ZRXKGE8YKF2McTciYhUHFtHVB0KMnjeFSU0qpztGhsp4P0uKix4+J2xEpIEDu8oXg==}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3836,8 +4049,15 @@ packages:
   '@simplewebauthn/browser@13.1.0':
     resolution: {integrity: sha512-WuHZ/PYvyPJ9nxSzgHtOEjogBhwJfC8xzYkPC+rR/+8chl/ft4ngjiK8kSU5HtRJfczupyOh33b25TjYbvwAcg==}
 
+  '@simplewebauthn/browser@13.2.0':
+    resolution: {integrity: sha512-N3fuA1AAnTo5gCStYoIoiasPccC+xPLx2YU88Dv0GeAmPQTWHETlZQq5xZ0DgUq1H9loXMWQH5qqUjcI7BHJ1A==}
+
   '@simplewebauthn/server@13.1.1':
     resolution: {integrity: sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@simplewebauthn/server@13.2.0':
+    resolution: {integrity: sha512-meBOTUhWZsQyrBcXDva82Tiyes5UlPQu+fKuMKQlhmAJwR/a+orU8xYfpTQviEaV7qEYD4aMj9He/eBj1KX9hA==}
     engines: {node: '>=20.0.0'}
 
   '@sinclair/typebox@0.27.8':
@@ -4724,6 +4944,38 @@ packages:
   better-auth@1.2.7:
     resolution: {integrity: sha512-2hCB263GSrgetsMUZw8vv9O1e4S4AlYJW3P4e8bX9u3Q3idv4u9BzDFCblpTLuL4YjYovghMCN0vurAsctXOAQ==}
 
+  better-auth@1.3.11:
+    resolution: {integrity: sha512-7l8bHX5rnON4vsVmWB7g2UucNpRlXnDUX/n65mHeR3Zn2/lcpQvfBvGbTaHYU8UGCQadtJ7DLHW/zA3ZR7IfdA==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@sveltejs/kit': ^2.0.0
+      next: ^14.0.0 || ^15.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.0.19:
+    resolution: {integrity: sha512-sI3GcA1SCVa3H+CDHl8W8qzhlrckwXOTKhqq3OOPXjgn5aTOMIqGY34zLY/pHA6tRRMjTUC3lz5Mi7EbDA24Kw==}
+
   better-call@1.0.9:
     resolution: {integrity: sha512-Qfm0gjk0XQz0oI7qvTK1hbqTsBY4xV2hsHAxF8LZfUYl3RaECCIifXuVqtPpZJWvlCCMlQSvkvhhyuApGUba6g==}
 
@@ -5052,6 +5304,10 @@ packages:
     resolution: {integrity: sha512-onMB0OkDjkXunhdW9htFjEhqrD54+M94i6ackoUkjHKbRnXdyEyKRelp4nJ1kAz32+s27jP1FsebpJCVl0BsvA==}
     engines: {node: '>=18.0'}
 
+  croner@9.1.0:
+    resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
+    engines: {node: '>=18.0'}
+
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -5336,6 +5592,10 @@ packages:
     resolution: {integrity: sha512-KqI+CS2Ga9GYIrXpxpCDUJJrH/AT/k4UY0Pb4oRgQEGkgN1EdCnqp664cXgwPWjDr5RBtTsjZipw8+8C//K63A==}
     hasBin: true
 
+  drizzle-kit@0.31.4:
+    resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
+    hasBin: true
+
   drizzle-orm@0.36.1:
     resolution: {integrity: sha512-F4hbimnMEhyWzDowQB4xEuVJJWXLHZYD7FYwvo8RImY+N7pStGqsbfmT95jDbec1s4qKmQbiuxEDZY90LRrfIw==}
     peerDependencies:
@@ -5422,6 +5682,98 @@ packages:
       prisma:
         optional: true
       react:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  drizzle-orm@0.44.2:
+    resolution: {integrity: sha512-zGAqBzWWkVSFjZpwPOrmCrgO++1kZ5H/rZ4qTGeGOe18iXGVJWf3WPfHOVwFIbmi8kHjfJstC6rJomzGx8g/dQ==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
         optional: true
       sql.js:
         optional: true
@@ -5541,6 +5893,11 @@ packages:
 
   esbuild@0.25.3:
     resolution: {integrity: sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6382,6 +6739,10 @@ packages:
     resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
+  ipaddr.js@2.2.0:
+    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+    engines: {node: '>= 10'}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -6608,6 +6969,9 @@ packages:
   jose@6.0.10:
     resolution: {integrity: sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==}
 
+  jose@6.1.0:
+    resolution: {integrity: sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -6691,6 +7055,10 @@ packages:
   kysely@0.27.6:
     resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
     engines: {node: '>=14.0.0'}
+
+  kysely@0.28.7:
+    resolution: {integrity: sha512-u/cAuTL4DRIiO2/g4vNGRgklEKNIj5Q3CG7RoUB5DV5SfEC2hMvPxKi0GWPmnzwL2ryIeud2VTcEEmqzTzEPNw==}
+    engines: {node: '>=20.0.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -7260,6 +7628,10 @@ packages:
     resolution: {integrity: sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  nanostores@1.0.1:
+    resolution: {integrity: sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   napi-postinstall@0.2.3:
     resolution: {integrity: sha512-Mi7JISo/4Ij2tDZ2xBE2WH+/KvVlkhA6juEjpEeRAVPNCpN3nxJo/5FhDNKgBcdmcmhaH6JjgST4xY/23ZYK0w==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -7671,6 +8043,13 @@ packages:
     peerDependencies:
       graphql: ^16.8.1
 
+  payload@3.55.1:
+    resolution: {integrity: sha512-HPAnDUMKnZRgODDMQ4m+w6o0d8bDxONl4Rtmc0DvsbdndW3VNc+dAHQZB/JXs4/WyGUwPkKnxUx56yr2zoyBUg==}
+    engines: {node: ^18.20.2 || >=20.9.0}
+    hasBin: true
+    peerDependencies:
+      graphql: ^16.8.1
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -7684,8 +8063,14 @@ packages:
   pg-cloudflare@1.2.5:
     resolution: {integrity: sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==}
 
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
   pg-connection-string@2.8.5:
     resolution: {integrity: sha512-Ni8FuZ8yAF+sWZzojvtLE2b03cqjO5jNULcHFfM9ZZ0/JXrgom5pBREbtnAw7oxsxJqHw9Nz/XWORUEL3/IFow==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -7695,10 +8080,18 @@ packages:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
     engines: {node: '>=4'}
 
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
   pg-pool@3.9.6:
     resolution: {integrity: sha512-rFen0G7adh1YmgvrmE5IPIqbb+IgEzENUm+tzm6MLLDSlPRoZVhzU1WdML9PV2W5GOdRA9qBKURlbt1OsXOsPw==}
     peerDependencies:
       pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
 
   pg-protocol@1.9.5:
     resolution: {integrity: sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==}
@@ -7714,6 +8107,15 @@ packages:
   pg@8.11.3:
     resolution: {integrity: sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==}
     engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
     peerDependenciesMeta:
@@ -8183,6 +8585,9 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -8886,6 +9291,9 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -8898,6 +9306,15 @@ packages:
     resolution: {integrity: sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   turbo-darwin-64@2.5.2:
     resolution: {integrity: sha512-2aIl0Sx230nLk+Cg2qSVxvPOBWCZpwKNuAMKoROTvWKif6VMpkWWiR9XEPoz7sHeLmCOed4GYGMjL1bqAiIS/g==}
@@ -9019,6 +9436,10 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  undici@7.10.0:
+    resolution: {integrity: sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==}
+    engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -9360,6 +9781,9 @@ packages:
   zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
 
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
+
   zustand@5.0.4:
     resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}
     engines: {node: '>=12.20.0'}
@@ -9445,15 +9869,26 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@better-auth/stripe@1.2.7':
+  '@better-auth/stripe@1.2.7(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      better-auth: 1.2.7
+      better-auth: 1.3.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod: 3.24.3
+    transitivePeerDependencies:
+      - '@lynx-js/react'
+      - '@sveltejs/kit'
+      - next
+      - react
+      - react-dom
+      - solid-js
+      - svelte
+      - vue
 
   '@better-auth/utils@0.2.4':
     dependencies:
       typescript: 5.8.2
       uncrypto: 0.1.3
+
+  '@better-auth/utils@0.3.0': {}
 
   '@better-fetch/fetch@1.1.18': {}
 
@@ -9830,6 +10265,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
@@ -9843,6 +10281,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -9860,6 +10301,9 @@ snapshots:
   '@esbuild/android-arm@0.25.3':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
@@ -9873,6 +10317,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.3':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -9890,6 +10337,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
@@ -9903,6 +10353,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -9920,6 +10373,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
@@ -9933,6 +10389,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -9950,6 +10409,9 @@ snapshots:
   '@esbuild/linux-arm64@0.25.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
@@ -9963,6 +10425,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -9980,6 +10445,9 @@ snapshots:
   '@esbuild/linux-ia32@0.25.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
@@ -9993,6 +10461,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -10010,6 +10481,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
@@ -10023,6 +10497,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -10040,6 +10517,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
@@ -10053,6 +10533,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -10070,7 +10553,13 @@ snapshots:
   '@esbuild/linux-x64@0.25.3':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/netbsd-x64@0.18.20':
@@ -10088,10 +10577,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -10109,6 +10604,12 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
@@ -10122,6 +10623,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.25.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
@@ -10139,6 +10643,9 @@ snapshots:
   '@esbuild/win32-arm64@0.25.3':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
@@ -10154,6 +10661,9 @@ snapshots:
   '@esbuild/win32-ia32@0.25.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
@@ -10167,6 +10677,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
@@ -10874,7 +11387,11 @@ snapshots:
 
   '@noble/ciphers@0.6.0': {}
 
+  '@noble/ciphers@2.0.0': {}
+
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -10997,13 +11514,13 @@ snapshots:
       - socks
       - supports-color
 
-  '@payloadcms/db-postgres@3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)':
+  '@payloadcms/db-postgres@3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)':
     dependencies:
-      '@payloadcms/drizzle': 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)
+      '@payloadcms/drizzle': 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)
       '@types/pg': 8.10.2
       console-table-printer: 2.12.1
       drizzle-kit: 0.28.0
-      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0)
+      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.11.3)(react@19.1.0)
       payload: 3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
       pg: 8.11.3
       prompts: 2.4.2
@@ -11040,15 +11557,15 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@payloadcms/db-postgres@3.35.1(@neondatabase/serverless@0.9.5)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)':
+  '@payloadcms/db-postgres@3.55.1(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))':
     dependencies:
-      '@payloadcms/drizzle': 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)
+      '@payloadcms/drizzle': 3.55.1(@types/pg@8.10.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.16.3)
       '@types/pg': 8.10.2
       console-table-printer: 2.12.1
-      drizzle-kit: 0.28.0
-      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0)
-      payload: 3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
-      pg: 8.11.3
+      drizzle-kit: 0.31.4
+      drizzle-orm: 0.44.2(@types/pg@8.10.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.16.3)
+      payload: 3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
+      pg: 8.16.3
       prompts: 2.4.2
       to-snake-case: 1.0.0
       uuid: 10.0.0
@@ -11065,31 +11582,31 @@ snapshots:
       - '@prisma/client'
       - '@tidbcloud/serverless'
       - '@types/better-sqlite3'
-      - '@types/react'
       - '@types/sql.js'
+      - '@upstash/redis'
       - '@vercel/postgres'
       - '@xata.io/client'
       - better-sqlite3
       - bun-types
       - expo-sqlite
+      - gel
       - knex
       - kysely
       - mysql2
       - pg-native
       - postgres
       - prisma
-      - react
       - sql.js
       - sqlite3
       - supports-color
 
-  '@payloadcms/db-vercel-postgres@3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)':
+  '@payloadcms/db-vercel-postgres@3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react@19.1.0)':
     dependencies:
-      '@payloadcms/drizzle': 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)
+      '@payloadcms/drizzle': 3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)
       '@vercel/postgres': 0.9.0
       console-table-printer: 2.12.1
       drizzle-kit: 0.28.0
-      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0)
+      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.11.3)(react@19.1.0)
       payload: 3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
       pg: 8.11.3
       prompts: 2.4.2
@@ -11126,10 +11643,10 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@payloadcms/drizzle@3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)':
+  '@payloadcms/drizzle@3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)':
     dependencies:
       console-table-printer: 2.12.1
-      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0)
+      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.11.3)(react@19.1.0)
       payload: 3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -11165,10 +11682,10 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@payloadcms/drizzle@3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)':
+  '@payloadcms/drizzle@3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)':
     dependencies:
       console-table-printer: 2.12.1
-      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0)
+      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.11.3)(react@19.1.0)
       payload: 3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -11204,11 +11721,12 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@payloadcms/drizzle@3.35.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.11.3)(react@19.1.0)':
+  '@payloadcms/drizzle@3.55.1(@types/pg@8.10.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(payload@3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(pg@8.16.3)':
     dependencies:
       console-table-printer: 2.12.1
-      drizzle-orm: 0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0)
-      payload: 3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
+      dequal: 2.0.3
+      drizzle-orm: 0.44.2(@types/pg@8.10.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.16.3)
+      payload: 3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
       prompts: 2.4.2
       to-snake-case: 1.0.0
       uuid: 9.0.0
@@ -11226,20 +11744,20 @@ snapshots:
       - '@tidbcloud/serverless'
       - '@types/better-sqlite3'
       - '@types/pg'
-      - '@types/react'
       - '@types/sql.js'
+      - '@upstash/redis'
       - '@vercel/postgres'
       - '@xata.io/client'
       - better-sqlite3
       - bun-types
       - expo-sqlite
+      - gel
       - knex
       - kysely
       - mysql2
       - pg
       - postgres
       - prisma
-      - react
       - sql.js
       - sqlite3
 
@@ -11468,6 +11986,10 @@ snapshots:
     dependencies:
       date-fns: 4.1.0
 
+  '@payloadcms/translations@3.55.1':
+    dependencies:
+      date-fns: 4.1.0
+
   '@payloadcms/ui@3.35.1(@types/react@19.0.10)(monaco-editor@0.52.2)(next@15.3.0(babel-plugin-react-compiler@19.0.0-beta-e993439-20250328)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)':
     dependencies:
       '@date-fns/tz': 1.2.0
@@ -11570,9 +12092,58 @@ snapshots:
       - supports-color
       - typescript
 
+  '@payloadcms/ui@3.35.1(@types/react@19.1.2)(monaco-editor@0.52.2)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.2)':
+    dependencies:
+      '@date-fns/tz': 1.2.0
+      '@dnd-kit/core': 6.0.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@faceless-ui/modal': 3.0.0-beta.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@faceless-ui/scroll-info': 2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@faceless-ui/window-info': 3.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@monaco-editor/react': 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@payloadcms/translations': 3.35.1
+      bson-objectid: 2.0.4
+      date-fns: 4.1.0
+      dequal: 2.0.3
+      md5: 2.3.0
+      next: 15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+      object-to-formdata: 4.5.1
+      payload: 3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5)
+      qs-esm: 7.0.2
+      react: 19.1.0
+      react-datepicker: 7.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-dom: 19.1.0(react@19.1.0)
+      react-image-crop: 10.1.8(react@19.1.0)
+      react-select: 5.9.0(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      scheduler: 0.25.0
+      sonner: 1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      ts-essentials: 10.0.3(typescript@5.8.2)
+      use-context-selector: 2.0.0(react@19.1.0)(scheduler@0.25.0)
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - monaco-editor
+      - supports-color
+      - typescript
+
   '@peculiar/asn1-android@2.3.16':
     dependencies:
       '@peculiar/asn1-schema': 2.3.15
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-cms@2.5.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
+      '@peculiar/asn1-x509-attr': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.5.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
       asn1js: 3.0.6
       tslib: 2.8.1
 
@@ -11583,10 +12154,51 @@ snapshots:
       asn1js: 3.0.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-ecc@2.5.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.5.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.5.0
+      '@peculiar/asn1-pkcs8': 2.5.0
+      '@peculiar/asn1-rsa': 2.5.0
+      '@peculiar/asn1-schema': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.5.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.5.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.5.0
+      '@peculiar/asn1-pfx': 2.5.0
+      '@peculiar/asn1-pkcs8': 2.5.0
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
+      '@peculiar/asn1-x509-attr': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-rsa@2.3.15':
     dependencies:
       '@peculiar/asn1-schema': 2.3.15
       '@peculiar/asn1-x509': 2.3.15
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.5.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
       asn1js: 3.0.6
       tslib: 2.8.1
 
@@ -11596,12 +12208,46 @@ snapshots:
       pvtsutils: 1.3.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-schema@2.5.0':
+    dependencies:
+      asn1js: 3.0.6
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.5.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-x509@2.3.15':
     dependencies:
       '@peculiar/asn1-schema': 2.3.15
       asn1js: 3.0.6
       pvtsutils: 1.3.6
       tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.5.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.5.0
+      asn1js: 3.0.6
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.5.0
+      '@peculiar/asn1-csr': 2.5.0
+      '@peculiar/asn1-ecc': 2.5.0
+      '@peculiar/asn1-pkcs9': 2.5.0
+      '@peculiar/asn1-rsa': 2.5.0
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -11615,16 +12261,16 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@polar-sh/better-auth@0.1.1(@polar-sh/sdk@0.32.13(zod@3.24.3))(better-auth@1.2.7)':
+  '@polar-sh/better-auth@0.1.1(@polar-sh/sdk@0.32.13(zod@4.1.8))(better-auth@1.3.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      '@polar-sh/sdk': 0.32.13(zod@3.24.3)
-      better-auth: 1.2.7
+      '@polar-sh/sdk': 0.32.13(zod@4.1.8)
+      better-auth: 1.3.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod: 3.24.3
 
-  '@polar-sh/sdk@0.32.13(zod@3.24.3)':
+  '@polar-sh/sdk@0.32.13(zod@4.1.8)':
     dependencies:
       standardwebhooks: 1.0.0
-      zod: 3.24.3
+      zod: 4.1.8
 
   '@radix-ui/number@1.1.1': {}
 
@@ -12887,6 +13533,8 @@ snapshots:
 
   '@simplewebauthn/browser@13.1.0': {}
 
+  '@simplewebauthn/browser@13.2.0': {}
+
   '@simplewebauthn/server@13.1.1':
     dependencies:
       '@hexagon/base64': 1.1.28
@@ -12896,6 +13544,17 @@ snapshots:
       '@peculiar/asn1-rsa': 2.3.15
       '@peculiar/asn1-schema': 2.3.15
       '@peculiar/asn1-x509': 2.3.15
+
+  '@simplewebauthn/server@13.2.0':
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.11
+      '@peculiar/asn1-android': 2.3.16
+      '@peculiar/asn1-ecc': 2.5.0
+      '@peculiar/asn1-rsa': 2.5.0
+      '@peculiar/asn1-schema': 2.5.0
+      '@peculiar/asn1-x509': 2.5.0
+      '@peculiar/x509': 1.14.0
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -13937,6 +14596,33 @@ snapshots:
       nanostores: 0.11.4
       zod: 3.24.3
 
+  better-auth@1.3.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.18
+      '@noble/ciphers': 2.0.0
+      '@noble/hashes': 2.0.0
+      '@simplewebauthn/browser': 13.2.0
+      '@simplewebauthn/server': 13.2.0
+      better-call: 1.0.19
+      defu: 6.1.4
+      jose: 6.1.0
+      kysely: 0.28.7
+      nanostores: 1.0.1
+      zod: 4.1.8
+    optionalDependencies:
+      next: 15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  better-call@1.0.19:
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.18
+      rou3: 0.5.1
+      set-cookie-parser: 2.7.1
+      uncrypto: 0.1.3
+
   better-call@1.0.9:
     dependencies:
       '@better-fetch/fetch': 1.1.18
@@ -14285,6 +14971,8 @@ snapshots:
 
   croner@9.0.0: {}
 
+  croner@9.1.0: {}
+
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.6
@@ -14529,35 +15217,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0):
+  drizzle-kit@0.31.4:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.9
+      esbuild-register: 3.6.0(esbuild@0.25.9)
+    transitivePeerDependencies:
+      - supports-color
+
+  drizzle-orm@0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.0.10)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.11.3)(react@19.1.0):
     optionalDependencies:
       '@neondatabase/serverless': 0.9.5
       '@types/pg': 8.10.2
       '@types/react': 19.0.10
       '@vercel/postgres': 0.9.0
-      kysely: 0.27.6
+      kysely: 0.28.7
       pg: 8.11.3
       react: 19.1.0
 
-  drizzle-orm@0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.10.2)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0):
-    optionalDependencies:
-      '@neondatabase/serverless': 0.9.5
-      '@types/pg': 8.10.2
-      '@types/react': 19.1.2
-      '@vercel/postgres': 0.9.0
-      kysely: 0.27.6
-      pg: 8.11.3
-      react: 19.1.0
-
-  drizzle-orm@0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.27.6)(pg@8.11.3)(react@19.1.0):
+  drizzle-orm@0.36.1(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.1.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.11.3)(react@19.1.0):
     optionalDependencies:
       '@neondatabase/serverless': 0.9.5
       '@types/pg': 8.11.6
       '@types/react': 19.1.2
       '@vercel/postgres': 0.9.0
-      kysely: 0.27.6
+      kysely: 0.28.7
       pg: 8.11.3
       react: 19.1.0
+
+  drizzle-orm@0.44.2(@types/pg@8.10.2)(@vercel/postgres@0.9.0)(kysely@0.28.7)(pg@8.16.3):
+    optionalDependencies:
+      '@types/pg': 8.10.2
+      '@vercel/postgres': 0.9.0
+      kysely: 0.28.7
+      pg: 8.16.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14722,6 +15416,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esbuild-register@3.6.0(esbuild@0.25.9):
+    dependencies:
+      debug: 4.4.0
+      esbuild: 0.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   esbuild@0.18.20:
     optionalDependencies:
       '@esbuild/android-arm': 0.18.20
@@ -14853,6 +15554,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.3
       '@esbuild/win32-ia32': 0.25.3
       '@esbuild/win32-x64': 0.25.3
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
 
   escalade@3.2.0: {}
 
@@ -16315,6 +17045,8 @@ snapshots:
       from2: 2.3.0
       p-is-promise: 3.0.0
 
+  ipaddr.js@2.2.0: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -16521,6 +17253,8 @@ snapshots:
 
   jose@6.0.10: {}
 
+  jose@6.1.0: {}
+
   joycon@3.1.1: {}
 
   js-cookie@3.0.5: {}
@@ -16594,6 +17328,8 @@ snapshots:
   kleur@3.0.3: {}
 
   kysely@0.27.6: {}
+
+  kysely@0.28.7: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -17381,6 +18117,8 @@ snapshots:
 
   nanostores@0.11.4: {}
 
+  nanostores@1.0.1: {}
+
   napi-postinstall@0.2.3: {}
 
   natural-compare@1.4.0: {}
@@ -17755,6 +18493,45 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  payload@3.55.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5):
+    dependencies:
+      '@next/env': 15.3.1
+      '@payloadcms/translations': 3.55.1
+      '@types/busboy': 1.5.4
+      ajv: 8.17.1
+      bson-objectid: 2.0.4
+      busboy: 1.6.0
+      ci-info: 4.2.0
+      console-table-printer: 2.12.1
+      croner: 9.1.0
+      dataloader: 2.2.3
+      deepmerge: 4.3.1
+      file-type: 19.3.0
+      get-tsconfig: 4.8.1
+      graphql: 16.11.0
+      http-status: 2.1.0
+      image-size: 2.0.2
+      ipaddr.js: 2.2.0
+      jose: 5.9.6
+      json-schema-to-typescript: 15.0.3
+      minimist: 1.2.8
+      path-to-regexp: 6.3.0
+      pino: 9.5.0
+      pino-pretty: 13.0.0
+      pluralize: 8.0.0
+      qs-esm: 7.0.2
+      sanitize-filename: 1.6.3
+      scmp: 2.1.0
+      ts-essentials: 10.0.3(typescript@5.8.2)
+      tsx: 4.20.3
+      undici: 7.10.0
+      uuid: 10.0.0
+      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   peberminta@0.9.0: {}
 
   peek-readable@5.4.2: {}
@@ -17764,15 +18541,26 @@ snapshots:
   pg-cloudflare@1.2.5:
     optional: true
 
+  pg-cloudflare@1.2.7:
+    optional: true
+
   pg-connection-string@2.8.5: {}
+
+  pg-connection-string@2.9.1: {}
 
   pg-int8@1.0.1: {}
 
   pg-numeric@1.0.2: {}
 
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
   pg-pool@3.9.6(pg@8.11.3):
     dependencies:
       pg: 8.11.3
+
+  pg-protocol@1.10.3: {}
 
   pg-protocol@1.9.5: {}
 
@@ -17805,6 +18593,16 @@ snapshots:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.2.5
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
 
   pgpass@1.0.5:
     dependencies:
@@ -18322,6 +19120,8 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -19204,6 +20004,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsx@4.19.2:
@@ -19219,6 +20021,17 @@ snapshots:
       get-tsconfig: 4.10.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   turbo-darwin-64@2.5.2:
     optional: true
@@ -19344,6 +20157,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
+
+  undici@7.10.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -19748,6 +20563,8 @@ snapshots:
   yoga-wasm-web@0.3.3: {}
 
   zod@3.24.3: {}
+
+  zod@4.1.8: {}
 
   zustand@5.0.4(@types/react@19.1.2)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
     optionalDependencies:


### PR DESCRIPTION
- Made admin config RSC-safe: replaced all functional labels with i18n string keys and removed any client-facing callbacks so the Admin only receives serializable JSON.
- Switched to a “generate then filter” flow: build the full BetterAuth schema server-side, pick only models enabled by options/plugins, then materialize Payload collections with deterministic FieldRules/Overrides.
- BetterAuth 1.3 updates: added adapter adapterConfig support, implemented transaction(), and updated refresh-token to pass the third boolean arg to setCookieCache.
- Organizations plugin sanitize: fixed field mappings, added guards for optional member.teamId and invitation.teamId, and ensured team.organizationId references the organization model.
- Added teamMember collection handling when present.
- Kept stable subpath exports (payload-auth/better-auth, payload-auth/better-auth/plugin); no app imports from dist required.
- Dependency hygiene: removed payload and better-auth from devDependencies; kept them as peerDependencies with relaxed ranges (also aligned @payloadcms/ui). Adjusted minor admin typings to avoid cross-version type conflicts.
- Ensured build outputs and types generation succeed under the new setup.